### PR TITLE
Enable package validation to track public API compatibility

### DIFF
--- a/src/Pure.RelationalSchema.Conditions/Pure.RelationalSchema.Conditions.csproj
+++ b/src/Pure.RelationalSchema.Conditions/Pure.RelationalSchema.Conditions.csproj
@@ -4,6 +4,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAotCompatible>true</IsAotCompatible>
+    <!--<EnablePackageValidation>true</EnablePackageValidation>-->
+    <!--<PackageValidationBaselineVersion>x.x.x</PackageValidationBaselineVersion>-->
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Pure.RelationalSchema.Conditions</PackageId>


### PR DESCRIPTION
Closes #18

Add `EnablePackageValidation` and `PackageValidationBaselineVersion` to the project file so that breaking public API changes are detected during build/pack before publishing.